### PR TITLE
Decode tree to unicode for json parsing

### DIFF
--- a/Products/RhaptosRepository/Repository.py
+++ b/Products/RhaptosRepository/Repository.py
@@ -230,7 +230,7 @@ class Repository(UniqueObject, DynamicType, StorageManager, BTreeFolder2):
             # can't get the collection tree, nothing to do
             raise KeyError(key)
 
-        tree = simplejson.loads(tree[0][0])
+        tree = simplejson.loads(tree[0][0].decode('utf-8'))
         modules = []
 
         def create_objects(contents, folder):


### PR DESCRIPTION
If titles of pages/modules had special character,s json choked. decode to unicode strings.
Fixes #6 