### PR TITLE
Set created and revised when creating collections from postgres

### DIFF
--- a/Products/RhaptosRepository/Repository.py
+++ b/Products/RhaptosRepository/Repository.py
@@ -211,6 +211,8 @@ class Repository(UniqueObject, DynamicType, StorageManager, BTreeFolder2):
         collection = _createObjectByType('Collection', vf, data['version'])
         collection.objectId = data['id']
         collection.version = data['version']
+        collection.created = DateTime(data['_created'].isoformat())
+        collection.revised = DateTime(data['_revised'].isoformat())
         for k, v in dict(title=data['name'], authors=data['authors'],
                          maintainers=data['maintainers'],
                          licensors=data['licensors'],


### PR DESCRIPTION
When creating collections in the ZODB from postgres database, "created"
and "revised" were not set so by default, the current date time is used.
This commit sets the "created" and "revised" field to the value
retrieved from the postgres database.

For existing collections in ZODB, it's possible to fix the "created" and
"revised" fields by doing the following in `./bin/instance debug`:

```
from DateTime import DateTime
from Products.CMFCore.utils import getToolByName
import transaction

moduledb_tool = getToolByName(app.plone, 'portal_moduledb')
for vf in app.plone.content.objectValues('Version Folder'):
    for collection in vf.objectValues('Collection'):
        data = moduledb_tool.sqlGetModule(
            id=collection.objectId, version=collection.version).dictionaries()[0]
        collection.created = DateTime(data['_created'].isoformat())
        collection.revised = DateTime(data['_revised'].isoformat())

transaction.commit()
```